### PR TITLE
DiscussionCard rework + join/leave

### DIFF
--- a/src/components/DiscussionCard.css
+++ b/src/components/DiscussionCard.css
@@ -1,0 +1,11 @@
+.flex {
+  display: flex;
+  justify-content: center;
+  gap: 5px;
+}
+.participants-icon {
+  align-self: center;
+}
+.participants {
+  align-self: center;
+}

--- a/src/components/DiscussionCard.tsx
+++ b/src/components/DiscussionCard.tsx
@@ -5,74 +5,208 @@ import {
   IonGrid,
   IonRow,
   IonButton,
+  IonLabel,
+  IonCardSubtitle,
 } from "@ionic/react";
-import { peopleCircle } from "ionicons/icons";
-import { useState } from "react";
+import {
+  chatbox,
+  chevronDownOutline,
+  chevronUpOutline,
+  clipboard,
+  pencil,
+  people,
+  peopleOutline,
+  personAdd,
+  personRemove,
+} from "ionicons/icons";
+import React, { useEffect, useState } from "react";
+import "./DiscussionCard.css";
+import { getCurrentUserId } from "../firebase/firebaseAuth";
+import {
+  addDiscussionParticipant,
+  getDiscussionDocument,
+  removeDiscussionParticipant,
+} from "../firebase/firebaseDiscussions";
 
 interface DiscussionCardProps {
-  bookClubId: string,
-  discussionId: string,
-  chapter: string;
-  participants: number;
+  bookClubId: string;
+  discussionId: string;
+  title: string;
+  date: string;
   startTime: string;
   endTime: string;
   location: string;
   agenda: string;
+  isModerator: boolean;
 }
 
 export const DiscussionCard: React.FC<DiscussionCardProps> = ({
   bookClubId,
   discussionId,
-  chapter,
-  participants,
+  title,
   startTime,
   endTime,
   location,
   agenda,
+  date,
+  isModerator,
 }: DiscussionCardProps) => {
   const [showButtons, setShowButtons] = useState<boolean>(false);
+  const [discussionParticipants, setDiscussionParticipants] =
+    useState<string[]>();
+
+  useEffect(() => {
+    getDiscussionParticipants();
+  }, []);
+
+  const isParticipant = () => {
+    return discussionParticipants?.includes(getCurrentUserId());
+  };
+
+  async function getDiscussionParticipants() {
+    let data = await getDiscussionDocument(bookClubId, discussionId);
+    setDiscussionParticipants(data?.participants);
+  }
+
+  async function joinDiscussion() {
+    if (discussionParticipants != null) {
+      await addDiscussionParticipant(
+        bookClubId,
+        discussionId,
+        getCurrentUserId()
+      );
+      getDiscussionParticipants();
+    }
+  }
+
+  async function leaveDiscussion() {
+    if (discussionParticipants != null && isParticipant()) {
+      await removeDiscussionParticipant(
+        bookClubId,
+        discussionId,
+        getCurrentUserId()
+      );
+      getDiscussionParticipants();
+    }
+  }
 
   return (
-    // show/hide buttons by clicking on the discussion card
-    <IonCard onClick={() => setShowButtons(!showButtons)}>
+    <IonCard>
       <IonGrid>
-        <IonRow>
-          <IonCol>
-            {chapter}
-            <br></br>
-            {startTime}
-            <br></br>
-            {endTime}
+        <IonRow
+          className="ion-align-items-center"
+          onClick={() => setShowButtons(!showButtons)}
+        >
+          <IonCol className="ion-text-left">{date}</IonCol>
+          <IonCol className="ion-text-center">
+            <div className="flex">
+              {!isParticipant() && (
+                <IonIcon
+                  className="participants-icon"
+                  icon={peopleOutline}
+                  size="small"
+                ></IonIcon>
+              )}
+              {isParticipant() && (
+                <IonIcon
+                  className="participants-icon"
+                  icon={people}
+                  size="small"
+                ></IonIcon>
+              )}
+              {discussionParticipants && (
+                <IonLabel className="participants">
+                  {discussionParticipants.length}
+                </IonLabel>
+              )}
+            </div>
           </IonCol>
-
-          <IonCol>
-            <IonIcon icon={peopleCircle} class="large-icon"></IonIcon>
-            {participants}
-          </IonCol>
-
-          <IonCol>
-            {location}
+          <IonCol className="ion-text-right">
+            {startTime + " - " + endTime}
           </IonCol>
         </IonRow>
-
+        <IonRow
+          className="ion-align-items-center"
+          onClick={() => setShowButtons(!showButtons)}
+        >
+          <IonCol className="ion-text-left">
+            <IonCardSubtitle>{title}</IonCardSubtitle>
+          </IonCol>
+          <IonCol className="ion-text-center">
+            {showButtons && (
+              <IonIcon icon={chevronDownOutline} size="large"></IonIcon>
+            )}
+            {!showButtons && (
+              <IonIcon icon={chevronUpOutline} size="large"></IonIcon>
+            )}
+          </IonCol>
+          <IonCol className="ion-text-right">
+            <IonCardSubtitle>{location}</IonCardSubtitle>
+          </IonCol>
+        </IonRow>
         {showButtons && (
-          <IonRow>
-            <IonCol>
-              <IonButton routerLink="/agenda">Outline </IonButton>
+          <IonRow className="ion-align-items-center">
+            <IonCol className="ion-text-center">
+              <IonButton routerLink="/agenda">
+                <IonIcon slot="icon-only" icon={clipboard}></IonIcon>
+              </IonButton>
+              <br></br>
+              <IonLabel>Agenda</IonLabel>
             </IonCol>
-            <IonCol>
-              <IonButton routerLink={"/clubs/" + bookClubId + "/discussions/" + discussionId + "/comments"}>Comments</IonButton>
+            <IonCol className="ion-text-center">
+              <IonButton
+                routerLink={
+                  "/clubs/" +
+                  bookClubId +
+                  "/discussions/" +
+                  discussionId +
+                  "/comments"
+                }
+              >
+                <IonIcon slot="icon-only" icon={chatbox}></IonIcon>
+              </IonButton>
+              <br></br>
+              <IonLabel>Comments</IonLabel>
             </IonCol>
-            <IonCol>
-              <IonButton routerLink={"/clubs/" + bookClubId + "/discussions/" + discussionId + "/edit"}>Edit</IonButton>
-            </IonCol>
-            <IonCol>
-              {/* {isModerator ? (
-                <IonButton>Edit</IonButton>
-              ) : (
-                <IonButton>Join</IonButton>
-              )} */}
-            </IonCol>
+            {isModerator && (
+              <IonCol className="ion-text-center">
+                <IonButton
+                  routerLink={
+                    "/clubs/" +
+                    bookClubId +
+                    "/discussions/" +
+                    discussionId +
+                    "/edit"
+                  }
+                >
+                  <IonIcon slot="icon-only" icon={pencil}></IonIcon>
+                </IonButton>
+                <br></br>
+                <IonLabel>Edit</IonLabel>
+              </IonCol>
+            )}
+            {!isModerator && (
+              <IonCol className="ion-text-center">
+                {discussionParticipants != null && !isParticipant() && (
+                  <>
+                    <IonButton onClick={joinDiscussion}>
+                      <IonIcon slot="icon-only" icon={personAdd}></IonIcon>
+                    </IonButton>
+                    <br></br>
+                    <IonLabel>Join</IonLabel>
+                  </>
+                )}
+                {discussionParticipants != null && isParticipant() && (
+                  <>
+                    <IonButton onClick={leaveDiscussion}>
+                      <IonIcon slot="icon-only" icon={personRemove}></IonIcon>
+                    </IonButton>
+                    <br></br>
+                    <IonLabel>Leave</IonLabel>
+                  </>
+                )}
+              </IonCol>
+            )}
           </IonRow>
         )}
       </IonGrid>

--- a/src/firebase/firebaseDiscussions.ts
+++ b/src/firebase/firebaseDiscussions.ts
@@ -1,5 +1,6 @@
 import {
   addDoc,
+  arrayRemove,
   arrayUnion,
   collection,
   deleteDoc,
@@ -10,7 +11,7 @@ import {
   setDoc,
   updateDoc,
 } from "firebase/firestore";
-import {  updateBookClubDocument } from "./firebaseBookClub";
+import { updateBookClubDocument } from "./firebaseBookClub";
 import { firebaseDB } from "./firebaseConfig";
 
 // Expected data format
@@ -28,22 +29,24 @@ async function createDiscussionDocument(bookClubId: string, data: any) {
 
 async function updateDiscussionDocument(bookClubId: string, discussionId: string, data: any) {
   const discussionDocument = doc(firebaseDB, "bookClubs", bookClubId, "discussions", discussionId);
-
   updateDoc(discussionDocument, data);
 }
 
-async function getDiscussionDocument(bookClubId:string, discussionId:string) {
+async function getDiscussionDocument(bookClubId: string, discussionId: string) {
   const discussionDocument = doc(firebaseDB, "bookClubs", bookClubId, "discussions", discussionId);
-  let discussionDocResult = await getDoc(discussionDocument)
-  let discussionData = discussionDocResult.data()
+  let discussionDocResult = await getDoc(discussionDocument);
+  let discussionData = discussionDocResult.data();
 
   if (discussionData) {
     return {
+      id: discussionData.id,
       title: discussionData.title,
       startTime: discussionData.startTime,
       endTime: discussionData.endTime,
-      location: discussionData.location
-    }
+      location: discussionData.location,
+      participants: discussionData.participants,
+      agenda: discussionData.agenda,
+    };
   }
 }
 // Needs to delete the discussion document and its subcollection of comments if available
@@ -56,11 +59,30 @@ async function deleteDiscussionDocument(bookClubId: string, discussionId: string
   let commentsQuery = query(
     collection(firebaseDB, "bookClubs", String(bookClubId), "discussions", String(discussionId), "comments"),
   );
-  
+
   var commentDocuments = await getDocs(commentsQuery);
   commentDocuments.forEach((doc) => {
-      deleteDoc(doc.ref)
-  })
+    deleteDoc(doc.ref);
+  });
+}
+
+async function addDiscussionParticipant(
+  bookClubId: string,
+  discussionId: string,
+  participantId: string
+) {
+  const discussionDocument = doc(firebaseDB, "bookClubs", bookClubId, "discussions", discussionId);
+  // Atomically add a new participant to the "participants" array field.
+  await updateDoc(discussionDocument, {
+    participants: arrayUnion(participantId),
+  });
+}
+async function removeDiscussionParticipant(bookClubId: string, discussionId: string, participantId: string) {
+  const discussionDocument = doc(firebaseDB, "bookClubs", bookClubId, "discussions", discussionId);
+  // Atomically remove a participant from the "participants" array field.
+  await updateDoc(discussionDocument, {
+    participants: arrayRemove(participantId),
+  });
 }
 
 export {
@@ -68,4 +90,6 @@ export {
   updateDiscussionDocument,
   deleteDiscussionDocument,
   getDiscussionDocument,
+  addDiscussionParticipant,
+  removeDiscussionParticipant,
 };

--- a/src/pages/clubs/ClubPage.tsx
+++ b/src/pages/clubs/ClubPage.tsx
@@ -17,65 +17,70 @@ import {
   IonCardContent,
   IonButton,
   IonIcon,
-  IonList,
-  IonItem,
   IonBackButton,
   IonButtons,
   IonFab,
   IonFabButton,
-  useIonViewWillEnter,
 } from "@ionic/react";
 import "./ClubPage.css";
 import { calendar, documents, add } from "ionicons/icons";
 import React, { useEffect, useState } from "react";
 import { DiscussionCard } from "../../components/DiscussionCard";
 import { ResourceCard } from "../../components/ResourceCard";
-import { BookClub, getBookClubDocument, addParticipant, removeParticipant } from "../../firebase/firebaseBookClub";
+import {
+  BookClub,
+  getBookClubDocument,
+  addParticipant,
+  removeParticipant,
+} from "../../firebase/firebaseBookClub";
 import { useParams } from "react-router";
 import { getCurrentUserId } from "../../firebase/firebaseAuth";
 
 const ClubPage: React.FC = () => {
   let { bookClubId }: { bookClubId: string } = useParams();
 
-  const [bookClubData, setBookClubData] = useState<BookClub>()
+  const [bookClubData, setBookClubData] = useState<BookClub>();
   const [selectedSegment, setSelectedSegment] = useState<string>("calendar");
   const [isModerator, setIsModerator] = useState<boolean>(true);
 
   useEffect(() => {
     getBookClub();
-
   }, []);
-  
+
   async function getBookClub() {
-    let bookClub = await getBookClubDocument(bookClubId)
+    let bookClub = await getBookClubDocument(bookClubId);
     // check if the current user is moderator of the club
     setIsModerator(bookClub?.moderator === getCurrentUserId());
-    setBookClubData(bookClub)
+    setBookClubData(bookClub);
   }
 
   async function joinClub() {
-    if(bookClubData != null
-      && bookClubData.participants.length < bookClubData.maxParticipantsNumber){
+    if (
+      bookClubData != null &&
+      bookClubData.participants.length < bookClubData.maxParticipantsNumber
+    ) {
       await addParticipant(bookClubId, getCurrentUserId());
       getBookClub();
     }
   }
 
   async function leaveClub() {
-    if(bookClubData != null
-      && bookClubData.participants.includes(getCurrentUserId())){
+    if (
+      bookClubData != null &&
+      bookClubData.participants.includes(getCurrentUserId())
+    ) {
       await removeParticipant(bookClubId, getCurrentUserId());
       getBookClub();
     }
   }
 
-  let clubName = bookClubData?.name
-  let bookTitle = bookClubData?.book.title
-  let bookAuthor = bookClubData?.book.authors
-  let bookCoverImg = bookClubData?.book.imageUrl
-  let bookCurrentChapter = "?"
-  let clubParticipants = bookClubData?.participants?.length
-  let clubParticipantsMax = bookClubData?.maxParticipantsNumber
+  let clubName = bookClubData?.name;
+  let bookTitle = bookClubData?.book.title;
+  let bookAuthor = bookClubData?.book.authors;
+  let bookCoverImg = bookClubData?.book.imageUrl;
+  let bookCurrentChapter = "?";
+  let clubParticipants = bookClubData?.participants?.length;
+  let clubParticipantsMax = bookClubData?.maxParticipantsNumber;
   // console.log(bookClubId)
   // console.log(getBookClubDiscussions(bookClubId))
   return (
@@ -85,7 +90,7 @@ const ClubPage: React.FC = () => {
           <IonButtons slot="start">
             <IonBackButton defaultHref="/clubs" />
           </IonButtons>
-          <IonTitle>{bookClubData?.name}</IonTitle>
+          <IonTitle>{clubName}</IonTitle>
         </IonToolbar>
       </IonHeader>
       <IonContent fullscreen>
@@ -110,15 +115,23 @@ const ClubPage: React.FC = () => {
                   <h3>
                     {clubParticipants}/{clubParticipantsMax}
                   </h3>
-                  {isModerator &&
-                  <IonButton routerLink={"/clubs/" + bookClubId + "/edit"}>Edit</IonButton>
-                  }
-                  {!isModerator && bookClubData != null && !bookClubData.participants.includes(getCurrentUserId()) &&
-                    <IonButton onClick={joinClub}>Join</IonButton>
-                  }
-                  {!isModerator && bookClubData != null && bookClubData.participants.includes(getCurrentUserId()) &&
-                    <IonButton onClick={leaveClub} color="danger">Leave</IonButton>
-                  }
+                  {isModerator && (
+                    <IonButton routerLink={"/clubs/" + bookClubId + "/edit"}>
+                      Edit
+                    </IonButton>
+                  )}
+                  {!isModerator &&
+                    bookClubData != null &&
+                    !bookClubData.participants.includes(getCurrentUserId()) && (
+                      <IonButton onClick={joinClub}>Join</IonButton>
+                    )}
+                  {!isModerator &&
+                    bookClubData != null &&
+                    bookClubData.participants.includes(getCurrentUserId()) && (
+                      <IonButton onClick={leaveClub} color="danger">
+                        Leave
+                      </IonButton>
+                    )}
                 </IonCardContent>
               </IonCol>
             </IonRow>
@@ -140,33 +153,31 @@ const ClubPage: React.FC = () => {
           </IonSegmentButton>
         </IonSegment>
 
-        <IonList lines="none">
-          {bookClubData?.discussions.map((discussion, index) => {
-            return (
-              <IonItem key={index}>
-                {selectedSegment === "calendar" ? (
-                  <DiscussionCard
-                    bookClubId={bookClubId}
-                    discussionId={discussion.id}
-                    chapter={discussion.title}
-                    participants={discussion.participants.length}
-                    startTime={discussion.startTime}
-                    endTime={discussion.endTime}
-                    location={discussion.location}
-                    agenda={discussion.agenda}
-                  />
-                ) : (
-                  <ResourceCard
-                    title={"Diva-E's Resource"}
-                    date={"12.12.2022"}
-                    type={"Link"}
-                  />
-                )}
-              </IonItem>
-            );
-          })}
-        </IonList>
-
+        {bookClubData?.discussions.map((discussion, index) => {
+          return (
+            <div key={index}>
+              {selectedSegment === "calendar" ? (
+                <DiscussionCard
+                  bookClubId={bookClubId}
+                  discussionId={discussion.id}
+                  title={discussion.title}
+                  date={"15.12.2022"}
+                  startTime={discussion.startTime}
+                  endTime={discussion.endTime}
+                  location={discussion.location}
+                  agenda={discussion.agenda}
+                  isModerator={isModerator}
+                />
+              ) : (
+                <ResourceCard
+                  title={"Diva-E's Resource"}
+                  date={"12.12.2022"}
+                  type={"Link"}
+                />
+              )}
+            </div>
+          );
+        })}
         {isModerator && (
           <IonFab slot="fixed" vertical="bottom" horizontal="end">
             <IonFabButton


### PR DESCRIPTION
Reworked the look of the Discussion Cards and made them fit the screen size and spacing. Additionally implemented the join/leave functionality as previously done by Marina for the BookClubs. For this to work, the discussions themselves need to update the participants, which has them fetch their data by themselves. (Just an Idea:) We could therefore also have the discussions get all their data themselves, instead of passing it from the ClubPage. We should really check how to save and read the date & time as well
<img width="313" alt="Bildschirm­foto 2022-12-16 um 16 42 13" src="https://user-images.githubusercontent.com/116285904/208141685-38e184ba-6749-4b32-b309-bab48fa5f8d6.png">
<img width="314" alt="Bildschirm­foto 2022-12-16 um 16 42 24" src="https://user-images.githubusercontent.com/116285904/208141697-8dadcad6-e61c-4c10-bcd8-7e198a6cd1f1.png">

