### PR TITLE
Club page&new discussion card

### DIFF
--- a/src/components/NewDiscussionCard.css
+++ b/src/components/NewDiscussionCard.css
@@ -1,0 +1,71 @@
+.calendarDate {
+  text-align: center;
+  border: 1px solid #0d0d0d;
+  border-radius: 15px;
+  width: 51px;
+}
+
+.date {
+  font-size: 25px;
+}
+
+.flexBetween {
+  display: flex;
+  justify-content: space-between;
+  gap: 5px;
+}
+
+.flex {
+  display: flex;
+  justify-content: space-evenly;
+  gap: 5px;
+}
+
+.flexStart {
+  display: flex;
+  justify-content: start;
+  gap: 10px;
+}
+
+.flexbox {
+  align-self: center;
+}
+
+ion-col {
+  --ion-grid-column-padding: 0px;
+}
+
+.locationBox {
+  align-self: center;
+  font-size: 14px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.title {
+  font-size: 18px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.spacing {
+  width: 10px;
+}
+
+.time {
+  font-size: 14px;
+  color: grey;
+  font-weight: bold;
+}
+
+.chipIsParticipant {
+  --background: var(--ion-color-primary);
+  --color: #ffffff;
+}
+
+.discussionMembersSpacing {
+  text-align: center;
+  min-width: 18px;
+}

--- a/src/components/NewDiscussionCard.tsx
+++ b/src/components/NewDiscussionCard.tsx
@@ -1,0 +1,229 @@
+import React, { useEffect, useRef, useState } from "react";
+import {
+  IonButton,
+  IonChip,
+  IonCol,
+  IonGrid,
+  IonIcon,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonPopover,
+  IonRow,
+  IonText,
+} from "@ionic/react";
+import {
+  getDayValue,
+  getMonthName,
+  getTimeSlotString,
+} from "../helpers/datetimeFormatter";
+import {
+  chatbox,
+  clipboard,
+  ellipsisVertical,
+  people,
+  locationOutline,
+  pencil,
+  trashOutline,
+} from "ionicons/icons";
+import "./NewDiscussionCard.css";
+import { useSelector } from "react-redux";
+import {
+  addDiscussionParticipant,
+  getDiscussionDocument,
+  removeDiscussionParticipant,
+} from "../firebase/firebaseDiscussions";
+
+interface NewDiscussionCardProps {
+  bookClubId: string;
+  discussionId: string;
+  title: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+  discussionLocation: string;
+  isModerator: boolean;
+  isMember?: boolean;
+  isDone?: boolean;
+}
+
+export const NewDiscussionCard: React.FC<NewDiscussionCardProps> = ({
+  bookClubId,
+  discussionId,
+  title,
+  startTime,
+  endTime,
+  discussionLocation,
+  date,
+  isModerator,
+  isMember,
+  isDone,
+}: NewDiscussionCardProps) => {
+  const user = useSelector((state: any) => state.user.user);
+  const [discussionParticipants, setDiscussionParticipants] =
+    useState<string[]>();
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  const popover = useRef<HTMLIonPopoverElement>(null);
+
+  useEffect(() => {
+    getDiscussionParticipants();
+  }, []);
+
+  const isParticipant = () => {
+    return discussionParticipants?.includes(user.uid);
+  };
+
+  async function getDiscussionParticipants() {
+    let data = await getDiscussionDocument(bookClubId, discussionId);
+    setDiscussionParticipants(data?.participants);
+  }
+
+  const handleJoinLeave = () => {
+    if (!isParticipant()) {
+      joinDiscussion();
+    } else {
+      leaveDiscussion();
+    }
+  };
+
+  async function joinDiscussion() {
+    if (discussionParticipants != null) {
+      await addDiscussionParticipant(bookClubId, discussionId, user.uid);
+      getDiscussionParticipants();
+    }
+  }
+
+  async function leaveDiscussion() {
+    if (discussionParticipants != null && isParticipant()) {
+      await removeDiscussionParticipant(bookClubId, discussionId, user.uid);
+      getDiscussionParticipants();
+    }
+  }
+
+  const openPopover = (e: any) => {
+    popover.current!.event = e;
+    setPopoverOpen(true);
+  };
+
+  const moderatorPopover = () => {
+    return (
+      <IonPopover
+        ref={popover}
+        isOpen={popoverOpen}
+        dismissOnSelect={true}
+        onDidDismiss={() => setPopoverOpen(false)}
+      >
+        <IonList lines="full">
+          <IonItem
+            button
+            detail={false}
+            routerLink={
+              "/clubs/" + bookClubId + "/discussions/" + discussionId + "/edit"
+            }
+          >
+            <IonLabel class="ion-padding-start">Edit</IonLabel>
+            <IonIcon class="ion-padding-end" slot="end" icon={pencil}></IonIcon>
+          </IonItem>
+          {/*The Delete Button here does not work yet. Use the Button on the EditDiscussionPage*/}
+          <IonItem button detail={false} lines="none">
+            <IonLabel class="ion-padding-start" color="danger">
+              Delete
+            </IonLabel>
+            <IonIcon
+              class="ion-padding-end"
+              color="danger"
+              slot="end"
+              icon={trashOutline}
+            ></IonIcon>
+          </IonItem>
+        </IonList>
+      </IonPopover>
+    );
+  };
+
+  const calendarDate = (date: string) => {
+    return (
+      <div className="calendarDate">
+        <IonLabel>
+          <p>{getMonthName(date)}</p>
+          <IonText className="date">{getDayValue(date)}</IonText>
+        </IonLabel>
+      </div>
+    );
+  };
+
+  return (
+    <IonGrid fixed className="ion-padding-horizontal">
+      <IonRow>
+        <IonCol className="ion-grid-column">
+          <IonItem lines="none">
+            {calendarDate(date)}
+            <div className="spacing"></div>
+            <IonLabel>
+              <div className="title">{title}</div>
+              <div className="time">
+                {getTimeSlotString(startTime, endTime)}
+              </div>
+            </IonLabel>
+            {isModerator && (
+              <>
+                <IonButton onClick={openPopover} slot="end" fill="clear">
+                  <IonIcon slot="icon-only" icon={ellipsisVertical}></IonIcon>
+                </IonButton>
+                {moderatorPopover()}
+              </>
+            )}
+          </IonItem>
+        </IonCol>
+      </IonRow>
+      <IonRow>
+        <IonCol>
+          <IonItem lines="none">
+            <IonIcon size="small" icon={locationOutline}></IonIcon>
+            <div className="spacing"></div>
+            <IonLabel>
+              <div className="locationBox">{discussionLocation}</div>
+            </IonLabel>
+            <IonButton
+              fill="clear"
+              routerLink={
+                "/clubs/" +
+                bookClubId +
+                "/discussions/" +
+                discussionId +
+                "/comments"
+              }
+            >
+              <IonIcon slot="icon-only" icon={chatbox}></IonIcon>
+            </IonButton>
+            <IonButton
+              fill="clear"
+              routerLink={
+                "/clubs/" +
+                bookClubId +
+                "/discussions/" +
+                discussionId +
+                "/agenda"
+              }
+            >
+              <IonIcon slot="icon-only" icon={clipboard}></IonIcon>
+            </IonButton>
+            <IonChip
+              disabled={isDone || !isMember}
+              onClick={() => handleJoinLeave()}
+              className={isParticipant() ? "chipIsParticipant" : ""}
+            >
+              <IonIcon
+                color={isParticipant() ? "white" : ""}
+                icon={people}
+              ></IonIcon>
+              <p className="discussionMembersSpacing">
+                {discussionParticipants ? discussionParticipants.length : "0"}
+              </p>
+            </IonChip>
+          </IonItem>
+        </IonCol>
+      </IonRow>
+    </IonGrid>
+  );
+};

--- a/src/components/clubPage/ArchiveSegment.tsx
+++ b/src/components/clubPage/ArchiveSegment.tsx
@@ -1,0 +1,84 @@
+import {
+  getDiscussionsByYear,
+  getPastDiscussions,
+  getYearArrayOfDiscussions,
+} from "../../helpers/discussionSort";
+import {
+  IonItem,
+  IonItemDivider,
+  IonItemGroup,
+  IonLabel,
+  IonSpinner,
+} from "@ionic/react";
+import { NewDiscussionCard } from "../NewDiscussionCard";
+import React from "react";
+import { BookClub } from "../../firebase/firebaseBookClub";
+
+interface ArchiveSegmentProps {
+  bookClubId: string;
+  bookClubData?: BookClub;
+  isModerator: boolean;
+}
+
+export const ArchiveSegment: React.FC<ArchiveSegmentProps> = ({
+  bookClubId,
+  bookClubData,
+  isModerator,
+}: ArchiveSegmentProps) => {
+  const content = () => {
+    let discussions = bookClubData?.discussions;
+    if (discussions) {
+      let pastDiscussions = getPastDiscussions(discussions);
+      let discussionYears = getYearArrayOfDiscussions(pastDiscussions);
+
+      return (
+        <>
+          {pastDiscussions.length === 0 && (
+            <div className="ion-padding-horizontal">
+              <IonItem lines="none">
+                <IonLabel>
+                  <p>There are no past discussions</p>
+                </IonLabel>
+              </IonItem>
+            </div>
+          )}
+          {discussionYears.map((year, index) => {
+            return (
+              <IonItemGroup key={index}>
+                <IonItemDivider>{year}</IonItemDivider>
+                {getDiscussionsByYear(year, pastDiscussions).map(
+                  (discussion, index) => {
+                    return (
+                      <IonItem class="ion-no-padding" key={index}>
+                        <NewDiscussionCard
+                          bookClubId={bookClubId}
+                          discussionId={discussion.id}
+                          title={discussion.title}
+                          date={discussion.date}
+                          startTime={discussion.startTime}
+                          endTime={discussion.endTime}
+                          discussionLocation={discussion.location}
+                          isModerator={isModerator}
+                          isDone={true}
+                        />
+                      </IonItem>
+                    );
+                  }
+                )}
+              </IonItemGroup>
+            );
+          })}
+        </>
+      );
+    }
+  };
+  return (
+    <>
+      <div className="ion-padding-horizontal">
+        <IonItem lines="none">Past Discussions</IonItem>
+      </div>
+      {!bookClubData && <IonSpinner></IonSpinner>}
+      {bookClubData && content()}
+    </>
+  );
+};

--- a/src/components/clubPage/ResourcesSegment.tsx
+++ b/src/components/clubPage/ResourcesSegment.tsx
@@ -1,0 +1,78 @@
+import {
+  IonButton,
+  IonIcon,
+  IonItem,
+  IonLabel,
+  IonSpinner,
+} from "@ionic/react";
+import React from "react";
+import { BookClub } from "../../firebase/firebaseBookClub";
+import { add } from "ionicons/icons";
+import { ResourceCard } from "../ResourceCard";
+
+interface ResourcesSegmentProps {
+  bookClubId: string;
+  bookClubData?: BookClub;
+  isModerator: boolean;
+  isMember: boolean;
+}
+
+export const ResourcesSegment: React.FC<ResourcesSegmentProps> = ({
+  bookClubId,
+  bookClubData,
+  isModerator,
+  isMember,
+}: ResourcesSegmentProps) => {
+  const content = () => {
+    let resources = bookClubData?.resources;
+    if (resources) {
+      return (
+        <>
+          {resources.length === 0 && (
+            <div className="ion-padding-horizontal">
+              <IonItem lines="none">
+                <IonLabel>
+                  <p>There are no resources</p>
+                </IonLabel>
+              </IonItem>
+            </div>
+          )}
+          {resources.map((resource, index) => {
+            return (
+              <div className="ion-padding-horizontal" key={index}>
+                <ResourceCard
+                  resourceId={resource.id}
+                  title={resource.title}
+                  content={resource.content}
+                  moderator={resource.moderator}
+                  bookClubId={bookClubId}
+                />
+              </div>
+            );
+          })}
+        </>
+      );
+    }
+  };
+
+  return (
+    <>
+      <div className="ion-padding-horizontal">
+        <IonItem lines="none">
+          <IonLabel>Resources</IonLabel>
+          {(isMember || isModerator) && (
+            <IonButton
+              fill="clear"
+              slot="end"
+              routerLink={"/clubs/" + bookClubId + "/resources/add"}
+            >
+              <IonIcon slot="icon-only" icon={add}></IonIcon>
+            </IonButton>
+          )}
+        </IonItem>
+      </div>
+      {!bookClubData && <IonSpinner></IonSpinner>}
+      {bookClubData && content()}
+    </>
+  );
+};

--- a/src/components/clubPage/UpcomingDiscussionsSegment.tsx
+++ b/src/components/clubPage/UpcomingDiscussionsSegment.tsx
@@ -1,0 +1,104 @@
+import { BookClub } from "../../firebase/firebaseBookClub";
+import React from "react";
+import {
+  getDiscussionsByYear,
+  getUpcomingDiscussions,
+  getYearArrayOfDiscussions,
+} from "../../helpers/discussionSort";
+import {
+  IonButton,
+  IonIcon,
+  IonItem,
+  IonItemDivider,
+  IonItemGroup,
+  IonLabel,
+  IonSpinner,
+} from "@ionic/react";
+import { add } from "ionicons/icons";
+import { NewDiscussionCard } from "../NewDiscussionCard";
+
+interface UpcomingDiscussionsSegmentProps {
+  bookClubId: string;
+  bookClubData?: BookClub;
+  isModerator: boolean;
+  isMember: boolean;
+}
+
+export const UpcomingDiscussionsSegment: React.FC<
+  UpcomingDiscussionsSegmentProps
+> = ({
+  bookClubId,
+  bookClubData,
+  isModerator,
+  isMember,
+}: UpcomingDiscussionsSegmentProps) => {
+  const content = () => {
+    let discussions = bookClubData?.discussions;
+
+    if (discussions) {
+      let upcomingDiscussions = getUpcomingDiscussions(discussions);
+      let discussionYears = getYearArrayOfDiscussions(upcomingDiscussions);
+
+      return (
+        <>
+          {upcomingDiscussions.length === 0 && (
+            <div className="ion-padding-horizontal">
+              <IonItem lines="none">
+                <IonLabel>
+                  <p>There are no discussions planned</p>
+                </IonLabel>
+              </IonItem>
+            </div>
+          )}
+          {discussionYears.map((year, index) => {
+            return (
+              <IonItemGroup key={index}>
+                <IonItemDivider>{year}</IonItemDivider>
+                {getDiscussionsByYear(year, upcomingDiscussions).map(
+                  (discussion, index) => {
+                    return (
+                      <IonItem class="ion-no-padding" key={index}>
+                        <NewDiscussionCard
+                          bookClubId={bookClubId}
+                          discussionId={discussion.id}
+                          title={discussion.title}
+                          date={discussion.date}
+                          startTime={discussion.startTime}
+                          endTime={discussion.endTime}
+                          discussionLocation={discussion.location}
+                          isMember={isMember}
+                          isModerator={isModerator}
+                        />
+                      </IonItem>
+                    );
+                  }
+                )}
+              </IonItemGroup>
+            );
+          })}
+        </>
+      );
+    }
+  };
+
+  return (
+    <>
+      <div className="ion-padding-horizontal">
+        <IonItem lines="none">
+          <IonLabel>Upcoming Discussions</IonLabel>
+          {isModerator && (
+            <IonButton
+              fill="clear"
+              slot="end"
+              routerLink={"/clubs/" + bookClubId + "/discussions/add"}
+            >
+              <IonIcon slot="icon-only" icon={add}></IonIcon>
+            </IonButton>
+          )}
+        </IonItem>
+      </div>
+      {!bookClubData && <IonSpinner></IonSpinner>}
+      {bookClubData && content()}
+    </>
+  );
+};

--- a/src/firebase/firebaseBookClub.ts
+++ b/src/firebase/firebaseBookClub.ts
@@ -54,8 +54,8 @@ type BookClub = {
   id: string;
   name: string;
   moderator: string[];
-  participants: string[];
-  maxParticipantsNumber: number;
+  members: string[];
+  maxMemberNumber: number;
   book: Book;
   discussions: Discussion[];
   resources: Resource[];
@@ -150,8 +150,8 @@ async function getBookClubDocument(bookClubId: string) {
       id: bookClubData.id,
       name: bookClubData.name,
       moderator: bookClubData.moderator,
-      participants: bookClubData.participants,
-      maxParticipantsNumber: bookClubData.maxParticipantsNumber,
+      members: bookClubData.members,
+      maxMemberNumber: bookClubData.maxMemberNumber,
       book: bookClubData.book,
       discussions: discussionArray,
       resources: resourceArray,
@@ -161,13 +161,13 @@ async function getBookClubDocument(bookClubId: string) {
 }
 
 // serch book clubs by their name, book title
-// and where participants contains and not contains given participant id
-// (needed to find clubs where user is a participant and where not)
+// and where members contains and not contains given member id
+// (needed to find clubs where user is a member and where not)
 async function searchBookClubs(
   filter: string,
   inputText: string,
-  participantId: string,
-  includeParticipant: boolean,
+  memberId: string,
+  includeMember: boolean,
   resultsLimit: number,
   lastBookClubId?: string
 ) {
@@ -199,12 +199,12 @@ async function searchBookClubs(
     let lastBookClubDocumentResult = await getDoc(lastBookClubDocument);
     queryConstraints.push(startAfter(lastBookClubDocumentResult));
   }
-  if (includeParticipant) {
-    // find documents where user is in the list of participants
-    // to search by participants and club name/book title a corresponding index is needed
+  if (includeMember) {
+    // find documents where user is in the list of members
+    // to search by members and club name/book title a corresponding index is needed
     // https://console.firebase.google.com/project/diva-e-htw-bookclub/firestore/indexes
     queryConstraints.push(
-      where("participants", "array-contains", participantId)
+      where("members", "array-contains", memberId)
     );
     let q = query(collection(firebaseDB, "bookClubs"), ...queryConstraints);
     // returns documents from bookClubs collection matching all query constraints
@@ -212,14 +212,14 @@ async function searchBookClubs(
     return results.docs.map(docToBookClub);
   } else {
     // find all documents from bookClubs collection matching the search query
-    // regardles of their participants
+    // regardles of their members
     let q = query(collection(firebaseDB, "bookClubs"), ...queryConstraints);
     var results = await getDocs(q);
     return (
       results.docs
         .map(docToBookClub)
-        // remove clubs where our user is a participant
-        .filter((bookClub) => !bookClub.participants.includes(participantId))
+        // remove clubs where our user is a member
+        .filter((bookClub) => !bookClub.members.includes(memberId))
     );
   }
 }
@@ -231,8 +231,8 @@ function docToBookClub(doc: any) {
     id: doc.id,
     name: data.name,
     moderator: data.moderator,
-    participants: data.participants,
-    maxParticipantsNumber: data.maxParticipantsNumber,
+    members: data.members,
+    maxMemberNumber: data.maxMemberNumber,
     book: data.book,
     discussions: data.discussions,
     resources: data.resources,
@@ -241,19 +241,19 @@ function docToBookClub(doc: any) {
 }
 
 // https://firebase.google.com/docs/firestore/manage-data/add-data#update_elements_in_an_array
-async function addParticipant(bookClubId: string, participantId: string) {
+async function addMember(bookClubId: string, memberId: string) {
   const bookClubDocument = doc(firebaseDB, "bookClubs", bookClubId);
-  // Atomically add a new participant to the "participants" array field.
+  // Atomically add a new member to the "members" array field.
   await updateDoc(bookClubDocument, {
-    participants: arrayUnion(participantId),
+    members: arrayUnion(memberId),
   });
 }
 
-async function removeParticipant(bookClubId: string, participantId: string) {
+async function removeMember(bookClubId: string, memberId: string) {
   const bookClubDocument = doc(firebaseDB, "bookClubs", bookClubId);
-  // Atomically remove a participant from the "participants" array field.
+  // Atomically remove a member from the "members" array field.
   await updateDoc(bookClubDocument, {
-    participants: arrayRemove(participantId),
+    members: arrayRemove(memberId),
   });
 }
 
@@ -263,8 +263,8 @@ export {
   deleteBookClubDocument,
   getBookClubDocument,
   searchBookClubs,
-  addParticipant,
-  removeParticipant,
+  addMember,
+  removeMember,
 };
 
 export type { BookClub, Discussion, Comment };

--- a/src/helpers/datetimeFormatter.tsx
+++ b/src/helpers/datetimeFormatter.tsx
@@ -1,4 +1,4 @@
-import { intervalToDuration } from "date-fns";
+import { compareAsc, intervalToDuration } from "date-fns";
 import { format, utcToZonedTime, zonedTimeToUtc } from "date-fns-tz";
 
 let timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -45,7 +45,7 @@ function getDistanceInterval(firstDate: string, lastDate: string) {
 
 function getDistanceInMinutes(firstDate: string, lastDate: string) {
   let interval = getDistanceInterval(firstDate, lastDate);
-  var distance = interval.minutes || 0;
+  let distance = interval.minutes || 0;
   if (interval.hours) {
     distance = distance + interval.hours * 60;
   }
@@ -58,6 +58,40 @@ function getTimeSlotString(firstDate: string, lastDate: string) {
   return startTime + " - " + endTime;
 }
 
+function getMonthName(datetime: string) {
+  const date = utcToZonedTime(datetime, timezone);
+  return format(date, "MMM", { timeZone: timezone });
+}
+
+function getDayValue(datetime: string) {
+  const date = utcToZonedTime(datetime, timezone);
+  return format(date, "d", { timeZone: timezone });
+}
+
+function getYearValue(datetime: string) {
+  const date = utcToZonedTime(datetime, timezone);
+  return format(date, "y", { timeZone: timezone });
+}
+
+function compareDatesAscending(firstDate: string, lastDate?: string) {
+  let result: number;
+  if (lastDate) {
+    result = compareAsc(new Date(firstDate), new Date(lastDate));
+  } else {
+    result = compareAsc(new Date(firstDate), new Date());
+  }
+
+  if (result === 1) {
+    return true;
+  }
+  if (result === 0) {
+    return true;
+  }
+  if (result === -1) {
+    return false;
+  }
+}
+
 export {
   getTimezonedDate,
   getTimezonedTime,
@@ -67,4 +101,8 @@ export {
   getDistanceInterval,
   getDistanceInMinutes,
   getTimeSlotString,
+  getMonthName,
+  getDayValue,
+  getYearValue,
+  compareDatesAscending,
 };

--- a/src/helpers/discussionSort.tsx
+++ b/src/helpers/discussionSort.tsx
@@ -1,0 +1,49 @@
+import { Discussion } from "../firebase/firebaseBookClub";
+import { compareDatesAscending, getYearValue } from "./datetimeFormatter";
+
+function sortDiscussionsByDate(discussions: Discussion[]) {
+  return discussions.sort((a, b) => {
+    return a.startTime < b.startTime ? -1 : a.startTime > b.startTime ? 1 : 0;
+  });
+}
+
+function getUpcomingDiscussions(discussions: Discussion[]) {
+  return discussions.filter((discussion) =>
+    compareDatesAscending(discussion.endTime)
+  );
+}
+
+function getPastDiscussions(discussions: Discussion[]) {
+  return discussions.filter(
+    (discussion) => !compareDatesAscending(discussion.endTime)
+  );
+}
+
+function getDiscussionsByYear(year: string, discussions: Discussion[]) {
+  discussions = sortDiscussionsByDate(discussions);
+  return discussions.filter(
+    (discussion) => getYearValue(discussion.date) === year
+  );
+}
+
+function getYearArrayOfDiscussions(discussions: Discussion[]) {
+  let yearsSet = new Set<string>();
+  discussions.forEach((discussion) => {
+    let year = getYearValue(discussion.date);
+    yearsSet.add(year);
+  });
+  let years: string[] = [];
+  yearsSet.forEach((year) => {
+    years.push(year);
+  });
+  years.sort();
+  return years;
+}
+
+export {
+  sortDiscussionsByDate,
+  getUpcomingDiscussions,
+  getPastDiscussions,
+  getDiscussionsByYear,
+  getYearArrayOfDiscussions,
+};

--- a/src/pages/clubs/ClubPage.css
+++ b/src/pages/clubs/ClubPage.css
@@ -5,3 +5,32 @@
 .large-icon {
   font-size: 28px;
 }
+
+.chipIsMember {
+  --background: var(--ion-color-primary);
+  --color: #ffffff;
+}
+
+.clubMembersSpacing {
+  text-align: center;
+  min-width: 38px;
+}
+
+.column {
+  padding-right: 10px;
+  min-height: 8rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.img-column {
+  padding-top: 10px;
+  padding-bottom: 5px;
+  min-height: 8rem;
+}
+
+.bookCover {
+  max-width: 110px;
+  filter: drop-shadow(0.0rem 0.3rem 0.3rem rgba(0, 0, 0, 0.65));
+}

--- a/src/pages/clubs/ClubPage.tsx
+++ b/src/pages/clubs/ClubPage.tsx
@@ -27,8 +27,8 @@ import React, { useEffect, useState } from "react";
 import {
   BookClub,
   getBookClubDocument,
-  addParticipant,
-  removeParticipant,
+  addMember,
+  removeMember,
 } from "../../firebase/firebaseBookClub";
 import { useParams } from "react-router";
 import { useSelector } from "react-redux";
@@ -53,20 +53,20 @@ const ClubPage: React.FC = () => {
     let bookClub = await getBookClubDocument(bookClubId);
     // check if the current user is moderator of the club
     setIsModerator(bookClub?.moderator.includes(user.uid));
-    setIsMember(bookClub?.participants.includes(user.uid));
+    setIsMember(bookClub?.members.includes(user.uid));
     setBookClubData(bookClub);
   }
 
   const handleJoinLeave = async () => {
     if (bookClubData != null && !isModerator) {
       if (
-        bookClubData.participants.length < bookClubData.maxParticipantsNumber
+        bookClubData.members.length < bookClubData.maxMemberNumber
       ) {
-        await addParticipant(bookClubId, user.uid);
+        await addMember(bookClubId, user.uid);
         getBookClub();
       }
-      if (bookClubData.participants.includes(user.uid)) {
-        await removeParticipant(bookClubId, user.uid);
+      if (bookClubData.members.includes(user.uid)) {
+        await removeMember(bookClubId, user.uid);
         getBookClub();
       }
     }
@@ -76,8 +76,8 @@ const ClubPage: React.FC = () => {
   let bookTitle = bookClubData?.book.title;
   let bookAuthor = bookClubData?.book.authors;
   let bookCoverImg = bookClubData?.book.imageUrl;
-  let clubParticipants = bookClubData?.participants?.length;
-  let clubParticipantsMax = bookClubData?.maxParticipantsNumber;
+  let clubMembers = bookClubData?.members?.length;
+  let clubMemberMax = bookClubData?.maxMemberNumber;
 
   return (
     <IonPage>
@@ -114,11 +114,11 @@ const ClubPage: React.FC = () => {
                       color={isMember || isModerator ? "white" : ""}
                       icon={people}
                     ></IonIcon>
-                    {!clubParticipants || !clubParticipantsMax ? (
+                    {!clubMembers || !clubMemberMax ? (
                       <IonSpinner name="dots"></IonSpinner>
                     ) : (
                       <p className="clubMembersSpacing">
-                        {clubParticipants + " / " + clubParticipantsMax}
+                        {clubMembers + " / " + clubMemberMax}
                       </p>
                     )}
                   </IonChip>

--- a/src/pages/clubs/ClubsTab.tsx
+++ b/src/pages/clubs/ClubsTab.tsx
@@ -123,7 +123,7 @@ const ClubsTab: React.FC = () => {
                 <ClubCard
                   id={bookClub.id}
                   name={bookClub.name}
-                  member={bookClub.participants.length}
+                  member={bookClub.members.length}
                   image={bookClub.book.imageUrl}
                   date={""}
                   time={""}

--- a/src/pages/clubs/CreateClubPage.tsx
+++ b/src/pages/clubs/CreateClubPage.tsx
@@ -28,7 +28,7 @@ const CreateClubPage: React.FC = () => {
   const [selectedBookIndex, setSelectedBookIndex] = useState<number>(0);
   const [query, setQuery] = useState<string>("");
   const [clubName, setClubName] = useState<string>("");
-  const [maxParticipants, setMaxParticipants] = useState<number>(0);
+  const [maxMember, setMaxMember] = useState<number>(0);
   const user = useSelector((state:any) => state.user.user)
 
   // calls HTTP API of OpenLibrary to search books by the given query and offset
@@ -92,8 +92,8 @@ const CreateClubPage: React.FC = () => {
       id: "",
       name: clubName,
       moderator: [userId],
-      participants: [userId],
-      maxParticipantsNumber: maxParticipants,
+      members: [userId],
+      maxMemberNumber: maxMember,
       book: {
         title: book.title,
         authors: book.author_name,
@@ -135,9 +135,9 @@ const CreateClubPage: React.FC = () => {
         </IonItem>
         <IonItem>
           <IonLabel position="stacked">
-            <h1>Max number of participants</h1>
+            <h1>Max number of members</h1>
           </IonLabel>
-          <IonInput required placeholder="Enter a number (max 50)" onIonInput={(e: any) => setMaxParticipants(e.target.value)}></IonInput>
+          <IonInput required placeholder="Enter a number (max 50)" onIonInput={(e: any) => setMaxMember(e.target.value)}></IonInput>
         </IonItem>
         <IonSearchbar placeholder="Find a book" debounce={1000} onIonInput={search}></IonSearchbar>
 

--- a/src/pages/clubs/EditClubPage.tsx
+++ b/src/pages/clubs/EditClubPage.tsx
@@ -7,7 +7,7 @@ import { BookClub, deleteBookClubDocument, getBookClubDocument, updateBookClubDo
 
 type FormValues = {
     name: string;
-    maxParticipantsNumber: number;
+    maxMemberNumber: number;
 }
 const EditClubPage: React.FC = () => {
     let {bookClubId}: {bookClubId: string} = useParams();
@@ -24,7 +24,7 @@ const EditClubPage: React.FC = () => {
         let bookClub = await getBookClubDocument(bookClubId)
         
         setValue("name", bookClub?.name)
-        setValue("maxParticipantsNumber", bookClub?.maxParticipantsNumber)        
+        setValue("maxMemberNumber", bookClub?.maxMemberNumber)
       }
     
     
@@ -65,9 +65,9 @@ const EditClubPage: React.FC = () => {
                 </IonItem>
                 <IonItem>
                     <IonLabel position="stacked">
-                        <h1>Max number of participants</h1>
+                        <h1>Max number of members</h1>
                     </IonLabel>
-                    <IonInput {...register("maxParticipantsNumber", {})}/>
+                    <IonInput {...register("maxMemberNumber", {})}/>
 
                 </IonItem>
                 <IonButton type="submit" routerLink={"/clubs/" + bookClubId + "/view"}>Update</IonButton>


### PR DESCRIPTION
Happy New Year! This is the redesign of the discussionCard and the ClubPage. As this is a rather large pull request, I will explain some of the changes:

**The New Discussion Card:**

![Bildschirm­foto 2023-01-02 um 11 18 56](https://user-images.githubusercontent.com/116285904/210218472-b75fecaa-7187-436c-9043-fb744fbe1f36.png)

The new Card features a (to the necessary degree required ;D) responsive Grid Layout (check the look on IPad!). The Chip is clickable to join or leave a Discussion. The Icons route to the corresponding page. The Title & Location are responsive to the provided space on the Grid, but cut off once the space is limited using an ellipsis. 

The vertical ellipsis button is only visible if the user is the moderator of the Club. It features a Popover for special moderator actions:

![Bildschirm­foto 2023-01-02 um 11 24 13](https://user-images.githubusercontent.com/116285904/210219025-ce7d1f0e-e93b-4293-b766-01ec3a397d4d.png)

**Note**: The delete button does not work yet, one still has to use the edit page for now

**The ClubPage got a refactor and a redesign:**
The BookCover received a scale down, so the title & author receive more space. The image scales up when the screen size is large or the phone is in landscape. The join and leave is handled via a chip as well to keep it consistent. The Edit Button for a Club is moved to the Toolbar. 

![Bildschirm­foto 2023-01-02 um 11 31 20](https://user-images.githubusercontent.com/116285904/210219751-6cebc203-0729-4fc6-bc3d-06ebf0c3e03c.png)

The Discussions are now sorted! I wrote some helper methods for the sorting as we will need them on the HomePage as well and it declutters the ClubPage. The Discussions are grouped by year and sorted by the startTime (this also sorts by the whole date, as the ISO time values contain the whole date as well). Discussions whichs EndTime is in the past (compared to the date of the most recent render), will not be displayed in the UpcomingDiscussions anymore (as they are not upcoming anymore). Since the FabButton was disableing the access to some DiscussionCards, the add Button was moved next to the Section Title where it stays fixed.

![Bildschirm­foto 2023-01-02 um 11 36 40](https://user-images.githubusercontent.com/116285904/210220313-d6046054-f89c-4402-8f89-ecde9c051ada.png)

I pulled out the Sections of the ClubPage to components. This makes it much more readable and separates the multiple views. It is the reason why it states so many changes in the PR, sorry for that.

**A new Section: Archive**
While Discussions where the endTime is in the past are not displayed under Upcoming Discussions anymore, they are still available in a new section: The Archive.

![Bildschirm­foto 2023-01-02 um 11 43 21](https://user-images.githubusercontent.com/116285904/210221007-a94b00ab-2ae1-4887-9226-b505723ae769.png)

For the moment, these are sorted and displayed similarly to the upcoming discussions (ascending, grouped by year). The Chip for Joining/Leaving these discussions is disabled.

I know these are many changes, but most of them are intertwined. I would be glad to rework the CSS usage somewhen, if someone has suggestions, as it is not my strength (possibly pair programming). I would generelly like to discuss some CSS/Design aspects again in a future meeting. I am happy for any questions or comments. :)

![Bildschirm­foto 2023-01-02 um 12 12 44](https://user-images.githubusercontent.com/116285904/210223822-713da489-328a-40a0-aa48-5e41e06d4236.png)



