### PR TITLE
tab reload & join/leave disc fix

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,20 +76,25 @@ return <IonApp>
 
 export const TabRouting: React.FC = () => {
   const isLoggedIn = useSelector((state:any) => state.user.user)
+  const [selectedTab, setSelectedTab] = useState();
 
   const authRouteCheck = (component: JSX.Element) => {
     return isLoggedIn ? component : <Redirect to="/login"/>;
   }
 
+  const isSelected = (tab: string) => {
+    return tab === selectedTab;
+  }
+
   return (
   <IonContent>
-    <IonTabs>
+    <IonTabs onIonTabsWillChange={(e: any) => setSelectedTab(e.detail.tab)}>
       <IonRouterOutlet>
         <Route exact path="/tabs">
           <Redirect to="/tabs/home"/>
         </Route>
         <Route path="/tabs/clubs" render={() => authRouteCheck(<ClubsTab/>)} exact/>
-        <Route path="/tabs/home" render={() => authRouteCheck(<HomeTab/>)} exact/>
+        <Route path="/tabs/home" render={() => authRouteCheck(<HomeTab isSelected={isSelected("home")}/>)} exact/>
         <Route path="/tabs/home/:bookClubId/view" render={() => authRouteCheck(<ClubPage/>)} exact/>
         <Route path="/tabs/home/:bookClubId/discussions/:discussionId/comments" render={() => authRouteCheck(<Comments/>)} exact/>
         <Route path="/tabs/home/:bookClubId/discussions/:discussionId/agenda" render={() => authRouteCheck(<Agenda/>)} exact/>

--- a/src/components/NewDiscussionCard.css
+++ b/src/components/NewDiscussionCard.css
@@ -67,3 +67,8 @@ ion-col {
   text-align: center;
   min-width: 18px;
 }
+
+.chipSpinner {
+  width: 18px;
+  height: 18px;
+}

--- a/src/components/clubPage/EditClubModal.tsx
+++ b/src/components/clubPage/EditClubModal.tsx
@@ -87,7 +87,10 @@ export const EditClubModal: React.FC<EditClubModalProps> = ({
   async function deleteBookClub() {
     await deleteBookClubDocument(bookClubId).then(() => {
       setIsOpen(false);
-      setTimeout(() => history.push("/tabs/home"), 200);
+      setTimeout(() => {
+        history.replace("/tabs/home");
+        window.location.reload();
+      }, 200);
     });
   }
 

--- a/src/components/clubPage/UpcomingDiscussionsSegment.tsx
+++ b/src/components/clubPage/UpcomingDiscussionsSegment.tsx
@@ -37,7 +37,6 @@ export const UpcomingDiscussionsSegment: React.FC<
   }
 
   let discussions = bookClubData?.discussions;
-  console.log(discussions)
   let upcomingDiscussions = getUpcomingDiscussions(discussions);
   let discussionYears = getYearArrayOfDiscussions(upcomingDiscussions);
 


### PR DESCRIPTION
HomeTab now fetches data whenever the tab is switched to provide the most recent data when switching tabs. It still requires to be fetched whenever the Hometab is visible but I cannot get this to work yet. This will also fix the bug of discussions showing when the user did join on the club page on the home discussion card.

Joining and leaving a Discussion now only requires one tap instead of two and shows a progress indicator now as it takes some time to add a participant to a discussion. 