### PR TITLE
fix home refresh on focus

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,25 +76,20 @@ return <IonApp>
 
 export const TabRouting: React.FC = () => {
   const isLoggedIn = useSelector((state:any) => state.user.user)
-  const [selectedTab, setSelectedTab] = useState();
 
   const authRouteCheck = (component: JSX.Element) => {
     return isLoggedIn ? component : <Redirect to="/login"/>;
   }
 
-  const isSelected = (tab: string) => {
-    return tab === selectedTab;
-  }
-
   return (
   <IonContent>
-    <IonTabs onIonTabsWillChange={(e: any) => setSelectedTab(e.detail.tab)}>
+    <IonTabs>
       <IonRouterOutlet>
         <Route exact path="/tabs">
           <Redirect to="/tabs/home"/>
         </Route>
         <Route path="/tabs/clubs" render={() => authRouteCheck(<ClubsTab/>)} exact/>
-        <Route path="/tabs/home" render={() => authRouteCheck(<HomeTab isSelected={isSelected("home")}/>)} exact/>
+        <Route path="/tabs/home" render={() => authRouteCheck(<HomeTab/>)} exact/>
         <Route path="/tabs/home/:bookClubId/view" render={() => authRouteCheck(<ClubPage/>)} exact/>
         <Route path="/tabs/home/:bookClubId/discussions/:discussionId/comments" render={() => authRouteCheck(<Comments/>)} exact/>
         <Route path="/tabs/home/:bookClubId/discussions/:discussionId/agenda" render={() => authRouteCheck(<Agenda/>)} exact/>

--- a/src/components/clubPage/EditClubModal.tsx
+++ b/src/components/clubPage/EditClubModal.tsx
@@ -88,8 +88,7 @@ export const EditClubModal: React.FC<EditClubModalProps> = ({
     await deleteBookClubDocument(bookClubId).then(() => {
       setIsOpen(false);
       setTimeout(() => {
-        history.replace("/tabs/home");
-        window.location.reload();
+        history.push("/tabs/home");
       }, 200);
     });
   }

--- a/src/components/home/HomeDiscussionCard.tsx
+++ b/src/components/home/HomeDiscussionCard.tsx
@@ -25,13 +25,10 @@ interface HomeDiscussionCardProps {
   bookClubId: string;
   bookClubName: string;
   discussionId: string;
-  title: string;
   date: string;
   startTime: string;
   endTime: string;
-  discussionLocation: string;
-  isModerator: boolean;
-  updatePage?: () => void;
+  participants: string[];
   isMember?: boolean;
   isArchived?: boolean;
 }
@@ -40,13 +37,10 @@ export const HomeDiscussionCard: React.FC<HomeDiscussionCardProps> = ({
   bookClubId,
   bookClubName,
   discussionId,
-  title,
   startTime,
   endTime,
-  discussionLocation,
+  participants,
   date,
-  isModerator,
-  updatePage,
   isMember,
   isArchived,
 }: HomeDiscussionCardProps) => {
@@ -58,7 +52,7 @@ export const HomeDiscussionCard: React.FC<HomeDiscussionCardProps> = ({
 
   useEffect(() => {
     getDiscussionParticipants();
-  }, []);
+  }, [participants]);
 
   const isParticipant = () => {
     return discussionParticipants?.includes(user.uid);

--- a/src/pages/discussion/LiveDiscussion.tsx
+++ b/src/pages/discussion/LiveDiscussion.tsx
@@ -417,12 +417,12 @@ return () => clearInterval(interval);
         <div className="h2">Aktuelle Teilnehmer: {participantCount}</div>
         <div className="divider-small"></div>
         {isModerator &&
-        <IonButton className="live" routerLink={"/tabs/home"}  onClick={() => saveLiveDiscussion(true)}>
+        <IonButton className="live" routerDirection="back" routerLink={"/tabs/home"}  onClick={() => saveLiveDiscussion(true)}>
               End discussion
         </IonButton>
         }
         {!isModerator &&
-        <IonButton className="live" routerLink={"/tabs/home/" + bookClubId + "/view"} >
+        <IonButton className="live" routerDirection="back" routerLink={"/tabs/home"} >
               Leave discussion
         </IonButton>
         }


### PR DESCRIPTION
Fixed this massive bug with pretty straight forward logic. "Unfortunatly" this only works on the lowest page of the tab view, so HomeTab, ClubsTab, ProfileTab. I only implemented it on the HomeTab as we don't need the refetch on the other two. I noticed that these Tab views are always "present" under the other pages that are kind of laying above them. This is why we cannot track if the page is active or not as it is "forever" active as long as the tab view is present. However this special case makes it possible to always check the current url on the home page. If the current url is indeed "/tabs/home" I trigger a refetch of the data. Thereby, every access of the home page refreshes the data now and shows everything up to date. This also fixes that deleted book clubs were accessible after the deletion on the home page and makes it possible to show the user that he has joined a discussion on the club page correctly in the next discussions on the home page as well.

Concerning the Live Discussion: As we cannot implement this reload on the ClubPages, I decided to just redirect everyone to the home page when leaving or ending the live discussion. There it triggers the reload and the just held discussion is not shown in the next discussions anymore. When clicking on the relative club this triggers a rerender anyways and the discussion is displayed in the archive.

Try this out and tell me what you think about the little tweaks, especially with the live discussion now redirecting to the home page.