### PR TITLE
Fixed bug for open library search

### DIFF
--- a/src/helpers/openLibraryHelpers.tsx
+++ b/src/helpers/openLibraryHelpers.tsx
@@ -40,7 +40,11 @@ function toUpperCaseFirstLettersOfAllWords(string: string) {
             .toLowerCase()
             .split(' ')
             .map(function (word) {
-                return word[0].toUpperCase() + word.slice(1);
+                if(word[0] != undefined) {
+                    return word[0].toUpperCase() + word.slice(1);
+                } else {
+                    return word;
+                }
             })
             .join(' ');
     }


### PR DESCRIPTION
For some reason, the first letter in the author's name is sometimes undefined, so toUpperCase does not work and gives an error.
Added check for unidentified element.